### PR TITLE
Add parser for tty containers

### DIFF
--- a/lib/loghose.js
+++ b/lib/loghose.js
@@ -40,14 +40,24 @@ function loghose (opts) {
       return
     }
 
-    container.attach({stream: true, stdout: true, stderr: true}, function (err, stream) {
-      var filter = parser(data, opts)
+    container.inspect(function (err, info) {
+      if (err) {
+        throw err
+      }
 
-      streams[data.id] = stream
-      pump(
-          stream,
-          filter
-      ).pipe(result, {end: false})
+      container.attach({stream: true, stdout: true, stderr: true}, function (err, stream) {
+        if (err) {
+          throw err
+        }
+
+        opts.tty = info.Config.Tty
+
+        streams[data.id] = stream
+        pump(
+            stream,
+            parser(data, opts)
+        ).pipe(result, {end: false})
+      })
     })
   }
 }

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -4,7 +4,7 @@ var bl = require('bl')
 function parser (data, opts) {
   var toLine = opts.json ? toLineJSON : toLineString
 
-  var result = through.obj(parse)
+  var result = through.obj(opts.tty ? parseTty : parse)
 
   result.payload = bl()
   result.headers = bl()
@@ -14,12 +14,19 @@ function parser (data, opts) {
 
   return result
 
+  function parseTty (chunk, enc, cb) {
+    this.payload.append(chunk)
+
+    publish.bind(this)()
+
+    return cb()
+  }
+
   function parse (chunk, enc, cb) {
     var buffer = bl(chunk)
 
     while (buffer.length) {
       if (this.readingHeader) {
-
         readAndConsume(buffer, this.headers, 8 - this.headers.length)
 
         if (this.headers.length !== 8) {
@@ -46,6 +53,12 @@ function parser (data, opts) {
       this.payloadLength = 0
     }
 
+    publish.bind(this)()
+
+    return cb()
+  }
+
+  function publish () {
     if (opts.newline) {
       var lines = this.payload.toString().split('\n').slice(0, -1)
 
@@ -57,8 +70,6 @@ function parser (data, opts) {
       this.push(buildObject(this.payload))
       this.payload.consume(this.payload.length)
     }
-
-    return cb()
   }
 
   function buildObject (chunk) {
@@ -74,7 +85,7 @@ function parser (data, opts) {
   function toLineJSON (line) {
     try {
       return JSON.parse(line)
-    } catch(err) {
+    } catch (err) {
       return toLineString(line)
     }
   }

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -11,13 +11,14 @@ function parser (data, opts) {
   result.currentLength = 0
   result.payloadLength = 0
   result.readingHeader = true
+  result.publish = publish
 
   return result
 
   function parseTty (chunk, enc, cb) {
     this.payload.append(chunk)
 
-    publish.bind(this)()
+    this.publish()
 
     return cb()
   }
@@ -53,7 +54,7 @@ function parser (data, opts) {
       this.payloadLength = 0
     }
 
-    publish.bind(this)()
+    this.publish()
 
     return cb()
   }

--- a/test/parser/headers.js
+++ b/test/parser/headers.js
@@ -1,3 +1,4 @@
+/* global describe it beforeEach */
 var parser = require('../../lib/parser')
 var helper = require('../helper.js')
 
@@ -10,7 +11,6 @@ describe('The parser', function () {
   var lineParser
 
   describe('when processing headers', function () {
-
     beforeEach(function (done) {
       lineParser = parser(sampleOutput, {})
       done()
@@ -18,7 +18,6 @@ describe('The parser', function () {
 
     describe('split in two chunks', function () {
       it('consumes the headers correctly', function (done) {
-
         var firstFour = new Buffer(4)
         var lastFour = new Buffer(4)
 
@@ -30,12 +29,10 @@ describe('The parser', function () {
         helper.expectData(lineParser, [inputLine], done)
 
         helper.writeChunks(lineParser, [firstFour, lastFour, line])
-
       })
 
       describe('where the last chunk contains both headers and payload data', function () {
         it('consumes the headers correctly', function (done) {
-
           var firstFour = new Buffer(4)
           var line = new Buffer(inputLine + '\n')
           var rest = new Buffer(4 + line.length)
@@ -47,7 +44,6 @@ describe('The parser', function () {
           helper.expectData(lineParser, [inputLine], done)
 
           helper.writeChunks(lineParser, [firstFour, rest])
-
         })
       })
     })

--- a/test/parser/json.js
+++ b/test/parser/json.js
@@ -1,3 +1,4 @@
+/* global describe it beforeEach */
 var parser = require('../../lib/parser')
 var helper = require('../helper.js')
 
@@ -8,7 +9,6 @@ describe('The parser', function () {
   var lineParser
 
   describe('when passing --json', function () {
-
     describe('when not using --newline', function () {
       beforeEach(function (done) {
         lineParser = parser(sampleOutput, {json: true})

--- a/test/parser/newline.js
+++ b/test/parser/newline.js
@@ -1,3 +1,4 @@
+/* global describe it beforeEach */
 var parser = require('../../lib/parser')
 var helper = require('../helper.js')
 
@@ -8,7 +9,6 @@ describe('The parser', function () {
   var lineParser
 
   describe('when passing --newline', function () {
-
     beforeEach(function (done) {
       lineParser = parser(sampleOutput, {newline: true})
       done()
@@ -25,7 +25,7 @@ describe('The parser', function () {
       it('outputs the lines separately', function (done) {
         var data = [testData.verseOne, testData.verseTwo, testData.rest]
         helper.expectData(lineParser, data, done)
-        helper.writeChunks(lineParser, data.map(function (c) { return helper.buildBuffer(c + '\n')}))
+        helper.writeChunks(lineParser, data.map(function (c) { return helper.buildBuffer(c + '\n') }))
       })
     })
 
@@ -43,8 +43,7 @@ describe('The parser', function () {
 
         helper.expectData(lineParser, outputData, done)
 
-        helper.writeChunks(lineParser, inputData.map(function (c) { return helper.buildBuffer(c)}))
-
+        helper.writeChunks(lineParser, inputData.map(function (c) { return helper.buildBuffer(c) }))
       })
     })
 

--- a/test/parser/parser.js
+++ b/test/parser/parser.js
@@ -1,3 +1,4 @@
+/* global describe it beforeEach */
 var parser = require('../../lib/parser')
 var helper = require('../helper.js')
 var expect = require('chai').expect
@@ -19,7 +20,6 @@ describe('The parser', function () {
   })
 
   it('outputs the chunk wrapped in an object', function (done) {
-
     helper.expectData(lineParser, [testData.inputLine], done)
 
     helper.writeChunks(lineParser, [helper.buildBuffer(testData.inputLine + '\n')])
@@ -31,7 +31,7 @@ describe('The parser', function () {
 
       helper.expectData(lineParser, data, done)
 
-      helper.writeChunks(lineParser, data.map(function (chunk) { return helper.buildBuffer(chunk)}))
+      helper.writeChunks(lineParser, data.map(function (chunk) { return helper.buildBuffer(chunk) }))
     })
   })
 })

--- a/test/parser/tty.js
+++ b/test/parser/tty.js
@@ -1,0 +1,43 @@
+/* global describe it beforeEach */
+var parser = require('../../lib/parser')
+var helper = require('../helper.js')
+var expect = require('chai').expect
+
+var testData = require('../data')
+var sampleOutput = testData.sampleOutput
+
+function buildBuffer (line) {
+  return new Buffer(line, 'utf-8')
+}
+
+describe('The parser when using tty options', function () {
+  describe('when using a tty option', function () {
+    var lineParser
+
+    beforeEach(function (done) {
+      lineParser = parser(sampleOutput, {tty: true})
+      done()
+    })
+
+    it('is an object', function (done) {
+      expect(lineParser).to.be.an('object')
+      done()
+    })
+
+    it('outputs the chunk wrapped in an object', function (done) {
+      helper.expectData(lineParser, [testData.inputLine], done)
+
+      helper.writeChunks(lineParser, [buildBuffer(testData.inputLine + '\n')])
+    })
+
+    describe('when is sent multiple chunks', function () {
+      it('outputs each chunk separately', function (done) {
+        var data = [testData.verseOne, testData.verseTwo, testData.rest]
+
+        helper.expectData(lineParser, data, done)
+
+        helper.writeChunks(lineParser, data.map(function (chunk) { return buildBuffer(chunk) }))
+      })
+    })
+  })
+})


### PR DESCRIPTION
This commits add a parser for containers with the tty flag set:

Before attaching a container, it inspects it to check if tty is enabled.
If it is enabled, it will skip the parsing of the header, as not sent by docker API.

Let me know if you would like me to change something!
Thanks
andrea
