### PR TITLE
Add timestamp and keep log line original / with whitespaces

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -93,7 +93,7 @@ function parser (data, opts) {
   }
 
   function toLineString (line) {
-    return line.toString().trim()
+    return line.toString()
   }
 
   function readAndConsume (src, dest, count) {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -79,6 +79,7 @@ function parser (data, opts) {
       id: data.id.slice(0, 12),
       image: data.image,
       name: data.name,
+      time: new Date(),
       line: toLine(chunk)
     }
   }

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -79,7 +79,7 @@ function parser (data, opts) {
       id: data.id.slice(0, 12),
       image: data.image,
       name: data.name,
-      time: new Date(),
+      time: Date.now(),
       line: toLine(chunk)
     }
   }


### PR DESCRIPTION
- each line gets a timestamp, so async parsers could use the original time
- trim() removed whitespaces and java stack traces could not be parsed anymore 
