### PR TITLE
Fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 node_js:
   - "0.12"
-  - "0.11"
   - "0.10"
-  - "iojs"
-  - "iojs-v1.0.4"
-
+  - "4"
+  - "5"

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -93,7 +93,7 @@ function parser (data, opts) {
   }
 
   function toLineString (line) {
-    return line.toString()
+    return line.toString().replace(/\n$/, '')
   }
 
   function readAndConsume (src, dest, count) {

--- a/test/helper.js
+++ b/test/helper.js
@@ -34,6 +34,7 @@ module.exports.buildBuffer = function (line) {
 module.exports. expectData = function (lineParser, data, done) {
   var index = 0
   lineParser.pipe(through.obj(function (chunk, enc, cb) {
+    delete chunk.time
     expect(chunk).to.deep.equals(expectedData(data[index]))
     if (index === data.length - 1) {
       done()


### PR DESCRIPTION
We had some broken tests from #7 cc @megastef.

I have restored some part of `trim()` behavior removed. Given it's a log line, we should not have a `\n` at the end of it. Would you mind adding a test in for bot the time addition and the trim stuff?

You have commit access, just push to this PR :).
