### PR TITLE
Fix test and time property checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 node_js:
   - "0.12"
-  - "0.11"
   - "0.10"
-  - "iojs"
-  - "iojs-v1.0.4"
-
+  - "4"
+  - "5"

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -93,7 +93,7 @@ function parser (data, opts) {
   }
 
   function toLineString (line) {
-    return line.toString()
+    return line.toString().replace(/\n$/, '')
   }
 
   function readAndConsume (src, dest, count) {

--- a/test/helper.js
+++ b/test/helper.js
@@ -31,9 +31,13 @@ module.exports.buildBuffer = function (line) {
   return buffer
 }
 
-module.exports. expectData = function (lineParser, data, done) {
+module.exports.expectData = function (lineParser, data, done) {
   var index = 0
   lineParser.pipe(through.obj(function (chunk, enc, cb) {
+    expect(chunk).to.have.property('time')
+    expect(chunk.time).to.be.a('number')
+    expect(chunk.time).to.be.at.most(Date.now())
+    expect(chunk.time).to.be.at.least(Date.now() - 100)
     delete chunk.time
     expect(chunk).to.deep.equals(expectedData(data[index]))
     if (index === data.length - 1) {

--- a/test/helper.js
+++ b/test/helper.js
@@ -34,6 +34,7 @@ module.exports.buildBuffer = function (line) {
 module.exports. expectData = function (lineParser, data, done) {
   var index = 0
   lineParser.pipe(through.obj(function (chunk, enc, cb) {
+    delete chunk.time
     expect(chunk).to.deep.equals(expectedData(data[index]))
     if (index === data.length - 1) {
       done()

--- a/test/parser/newline.js
+++ b/test/parser/newline.js
@@ -51,10 +51,10 @@ describe('The parser', function () {
       var data = ['abcd', 'efgh']
 
       helper.expectData(lineParser, data, done)
-
-      var wholeBuffer = new Buffer(8 * 3 + 3 + testData.verseOne.length + testData.verseTwo.length + testData.rest.length)
-      helper.buildBuffer('abcd\n').copy(wholeBuffer)
-      helper.buildBuffer('efgh\n').copy(wholeBuffer, 8 + 5)
+      //                           header  content
+      var wholeBuffer = new Buffer(8 * 2 + 2 * 5)
+      helper.buildBuffer(data[0] + '\n').copy(wholeBuffer)
+      helper.buildBuffer(data[1] + '\n').copy(wholeBuffer, 8 + 5)
       helper.writeChunks(lineParser, [wholeBuffer])
     })
   })


### PR DESCRIPTION
1) Helper.js got checks for chunk.time (property exists and time in in range from now-100ms to now.
2) The test "--newline / merges incomplete buffers into one" was failing in https://github.com/mcollina/docker-loghose/pull/9. It works only when the buffer size is set correctly (2\* header size + content size). But I'm not sure if this was the intention of the test :) @cammellos or @mcollina might know... 

I made a new pull request because I've got a git error pushing to https://github.com/mcollina/docker-loghose/pull/9 (I did probably something wrong). 
