### PR TITLE
Catch error on docker-modem disconnect

### DIFF
--- a/lib/loghose.js
+++ b/lib/loghose.js
@@ -49,14 +49,14 @@ function loghose (opts) {
         if (err) {
           throw err
         }
-
         opts.tty = info.Config.Tty
-
         streams[data.id] = stream
         pump(
-            stream,
-            parser(data, opts)
-        ).pipe(result, {end: false})
+          stream,
+          parser(data, opts)
+        ).pipe(result, {end: false}).on('error', function () {
+          /* continue, let's wait for docker restart */
+        })
       })
     })
   }


### PR DESCRIPTION
Accoring to my tests catching and ignoring the error when Docker daemon restarts works - so docker loghose continues to receive logs after the restart Docker daemon (> Docker v1.11). 

Initially I've tried to emit the error via the "result" object, to make DLH users aware about the disconnect, e.g. to reconnect. But this did lead to a stack overflow. So this solution is "silent", but works for the scenario in issue https://github.com/mcollina/docker-loghose/issues/15

Demo: http://recordit.co/GuRtxVw48t
