### PR TITLE
ignore errors in inspect/attach

### DIFF
--- a/lib/loghose.js
+++ b/lib/loghose.js
@@ -43,7 +43,14 @@ function loghose (opts) {
     container.inspect(function (err, info) {
       if (err) {
         // container might not exists anymore ...
-        return
+        if (/no such container/i.test(err.toString())) {
+          // ignore this container and don't try to attach 
+          return
+        } else {
+          // any other error should be submitted to result stream
+          // TODO catch specific TCP/HTTP errors e.g. indicating lost of connection/timeouts to dockerd
+          return result.emit('error', err)
+        }
       }
 
       container.attach({stream: true, stdout: true, stderr: true}, function (err, stream) {

--- a/lib/loghose.js
+++ b/lib/loghose.js
@@ -42,12 +42,14 @@ function loghose (opts) {
 
     container.inspect(function (err, info) {
       if (err) {
-        throw err
+        // container might not exists anymore ...
+        return
       }
 
       container.attach({stream: true, stdout: true, stderr: true}, function (err, stream) {
         if (err) {
-          throw err
+           // no stream availaable
+          return
         }
         opts.tty = info.Config.Tty
         streams[data.id] = stream


### PR DESCRIPTION
please see my questions in #17 - there might be a better way to handle the case when a container gets killed before inspect call is finished. 
