### PR TITLE
Exposing detachContainer and full container id

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,19 @@ var opts = {
   skipByName: /.*pasteur.*/, //optional
   skipByImage: /.*dockerfile.*/ //optional
 }
-loghose(opts).pipe(through.obj(function(chunk, enc, cb) {
+var lh = loghose(opts)
+lh.pipe(through.obj(function(chunk, enc, cb) {
   this.push(JSON.stringify(chunk))
   this.push('\n')
+  // stop listening to specific container logs
+  if (/top secret logs/.test(chunk.line)) { 
+    lh.detachContainer(chunk.long_id)
+    // we should not get more logs for the container with chunk.long_id
+  }
   cb()
 })).pipe(process.stdout)
+
+
 ```
 
 ## Command Line Usage
@@ -67,6 +75,7 @@ docker run --rm -v /var/run/docker.sock:/var/run/docker.sock matteocollina/docke
 {
   v: 0,
   id: "3324acd73ad5",
+  long_id: "3324acd73ad573773b901d93e932be65f2bb55b8e6c03167a24c17ab3f172249"
   image: "myimage:latest",
   name: "mycontainer-name"
   time: 1454928524601,

--- a/lib/loghose.js
+++ b/lib/loghose.js
@@ -30,9 +30,13 @@ function loghose (opts) {
     }
   }
 
+  // exposing streams and detach function
+  result.streams = streams
+  result.detachContainer = detachContainer.bind(this)
   return result
 
   function attachContainer (data, container) {
+    console.log(data)
     // we are trying to tap into this container
     // we should not do that, or we might be stuck in
     // an output loop

--- a/lib/loghose.js
+++ b/lib/loghose.js
@@ -30,13 +30,11 @@ function loghose (opts) {
     }
   }
 
-  // exposing streams and detach function
-  result.streams = streams
+  // exposing detachContainer function
   result.detachContainer = detachContainer.bind(this)
   return result
 
   function attachContainer (data, container) {
-    console.log(data)
     // we are trying to tap into this container
     // we should not do that, or we might be stuck in
     // an output loop
@@ -63,7 +61,7 @@ function loghose (opts) {
           return
         }
         opts.tty = info.Config.Tty
-        streams[data.id] = stream
+        streams[data.id.substring(0,12)] = stream
         pump(
           stream,
           parser(data, opts)

--- a/lib/loghose.js
+++ b/lib/loghose.js
@@ -61,7 +61,7 @@ function loghose (opts) {
           return
         }
         opts.tty = info.Config.Tty
-        streams[data.id.substring(0,12)] = stream
+        streams[data.id] = stream
         pump(
           stream,
           parser(data, opts)

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -76,6 +76,7 @@ function parser (data, opts) {
     return {
       v: 0,
       id: data.id.slice(0, 12),
+      long_id: data.id,
       image: data.image,
       name: data.name,
       time: Date.now(),

--- a/test/data.js
+++ b/test/data.js
@@ -1,6 +1,7 @@
 
 module.exports.sampleOutput = {
   id: 'ABCDEFGHIJKL',
+  long_id: 'ABCDEFGHIJKL',
   image: 'test_image',
   name: 'test_image_name',
   v: 0


### PR DESCRIPTION
Fix for https://github.com/sematext/sematext-agent-docker/issues/28 
This requires the possibility to stop the log stream from specific containers. The PR exposes detachContainer function and adds long_id filed to each log, because detachContainer requires the full id. 

We can reduce the number of API calls to docker in an environment having 1k containers and only a small percentage of the containers require log collection. To switch off the log collection per container we have to evaluate first attached labels (SDA specific settings). I could imagine more users will like the option for a dynamic stop of log streaming from specific containers on custom conditions. 
