### PR TITLE
Allow use of label as as service name

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,17 @@ var opts = {
   docker: null, // here goes options for Dockerode
   events: null, // an instance of docker-allcontainers
   newline: false, // Break stream in newlines
+
   // Logs from the container, running docker-loghose are excluded by default.
   // It could create endless loops, when the same logs are written to stdout...
   // To get all logs set includeCurrentContainer to 'true'
   includeCurrentContainer: false, // default value: false
+  
+  // In a managed environment, container names may be obfuscated. 
+  // If there is a label that provides a better name for logging,
+  // provide the key here.
+  nameLabel: 'com.amazonaws.ecs.container-name',
+
   // the following options limit the containers being matched
   // so we can avoid catching logs for unwanted containers
   matchByName: /hello/, // optional

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -86,7 +86,7 @@ function parser (data, opts) {
       id: data.id.slice(0, 12),
       long_id: data.id,
       image: data.image,
-      name: data.name,
+      name: (data.labels && opts.nameLabel) ? data.labels[opts.nameLabel] : data.name,
       time: Date.now(),
       line: toLine(chunk)
     }

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -6,6 +6,8 @@ function parser (data, opts) {
 
   var result = through.obj(opts.tty ? parseTty : parse)
 
+  var name = (data.labels && opts.nameLabel && data.labels[opts.nameLabel]) ? data.labels[opts.nameLabel] : data.name
+
   result.payload = bl()
   result.headers = bl()
   result.currentLength = 0
@@ -86,7 +88,7 @@ function parser (data, opts) {
       id: data.id.slice(0, 12),
       long_id: data.id,
       image: data.image,
-      name: (data.labels && opts.nameLabel) ? data.labels[opts.nameLabel] : data.name,
+      name: name,
       time: Date.now(),
       line: toLine(chunk)
     }

--- a/loghose.js
+++ b/loghose.js
@@ -22,6 +22,7 @@ function cli () {
 
   if (argv.help) {
     console.log('Usage: docker-loghose [--json] [--newline] [--help]\n' +
+                '                      [--nameLabel label]\n' +
                 '                      [--matchByImage REGEXP] [--matchByName REGEXP]\n' +
                 '                      [--skipByImage REGEXP] [--skipByName REGEXP]')
     process.exit(1)
@@ -29,6 +30,7 @@ function cli () {
 
   loghose({
     includeCurrentContainer: false,
+    nameLabel: argv.nameLabel,
     matchByName: argv.matchByName,
     matchByImage: argv.matchByImage,
     skipByName: argv.skipByName,

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/mcollina/docker-loghose",
   "dependencies": {
     "bl": "^1.2.0",
-    "docker-allcontainers": "^0.6.1",
+    "docker-allcontainers": "^0.7.0",
     "minimist": "^1.1.1",
     "never-ending-stream": "^1.1.2",
     "pump": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/mcollina/docker-loghose",
   "dependencies": {
     "bl": "^1.2.0",
-    "docker-allcontainers": "^0.6.2",
+    "docker-allcontainers": "^0.6.1",
     "minimist": "^1.1.1",
     "never-ending-stream": "^1.1.2",
     "pump": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/mcollina/docker-loghose",
   "dependencies": {
     "bl": "^1.2.0",
-    "docker-allcontainers": "^0.6.0",
+    "docker-allcontainers": "^0.6.2",
     "minimist": "^1.1.1",
     "never-ending-stream": "^1.1.2",
     "pump": "^1.0.0",


### PR DESCRIPTION
In managed environments like ECS, the container name is obfuscated. In these cases, it is helpful to use a label instead to identify the service. This, in combination with https://github.com/mcollina/docker-allcontainers/pull/14, allows the user to specify a label which is to be used for name resolution.

This of course means that all containers should have the same label. This is in my experience usually the case in an environment like ECS. 