### PR TITLE
add opts.attachFilter

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ var opts = {
   matchByImage: /matteocollina/, //optional
   skipByName: /.*pasteur.*/, //optional
   skipByImage: /.*dockerfile.*/ //optional
+  attachFilter: function (id, dockerInspectInfo) {
+    // Optional filter function to decide if the log stream should 
+    // be attached to a container or not 
+    // e.g. return /LOGGING_ENABLED=true/i.test(dockerInspectInfo.Config.Env.toString())
+    return true
+  }
 }
 var lh = loghose(opts)
 lh.pipe(through.obj(function(chunk, enc, cb) {

--- a/lib/loghose.js
+++ b/lib/loghose.js
@@ -54,7 +54,12 @@ function loghose (opts) {
           return result.emit('error', err)
         }
       }
-
+      // optional attachFilter decides to attach to container or not
+      if (opts.attachFilter && 
+          typeof opts.attachFilter === 'function' && 
+          !opts.attachFilter(data.id, info)) {
+        return
+      }
       container.attach({stream: true, stdout: true, stderr: true}, function (err, stream) {
         if (err) {
            // no stream availaable


### PR DESCRIPTION
Docker-Loghose performs Docker inspect calls and the info from the inspect call could be very useful to decide if logs from containers should be collected or not. Users could decide to collect logs from containers with specific labels or ENV settings etc. This PR adds an optional function "attachFilter" to Docker-Loghose options to implement a custom logic for filters.    