### PR TITLE
add docker labels to each logentry

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ var opts = {
     // e.g. return /LOGGING_ENABLED=true/i.test(dockerInspectInfo.Config.Env.toString())
     return true
   }
+
+  // Enrich all log events with the labels that are set on the container
+  // Using a regular expression it's possible to limit which labels are set
+  // Labels are added into the root of JSON structure, unless 'labelsKey' is defined
+  addLabels: false // default
+  labelsMatch: /^ecs-.*/ // defaults to .*
+  labelsKey: labels // defaults to 'none'
 }
 var lh = loghose(opts)
 lh.pipe(through.obj(function(chunk, enc, cb) {
@@ -93,7 +100,10 @@ docker run --rm -v /var/run/docker.sock:/var/run/docker.sock matteocollina/docke
   image: "myimage:latest",
   name: "mycontainer-name"
   time: 1454928524601,
-  line: "This is a log line" // this will be an object if opts.jon is true
+  line: "This is a log line", // this will be an object if opts.jon is true
+  labels: {
+            com.amazonaws.ecs.cluster: "my-ecs-cluster"
+          } // labels placed in 'labels' when "--labelsKey labels"
 }
 ```
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -83,15 +83,32 @@ function parser (data, opts) {
   }
 
   function buildObject (chunk) {
-    return {
-      v: 0,
-      id: data.id.slice(0, 12),
-      long_id: data.id,
-      image: data.image,
-      name: name,
-      time: Date.now(),
-      line: toLine(chunk)
+    var obj = {
+                v: 0,
+                id: data.id.slice(0, 12),
+                long_id: data.id,
+                image: data.image,
+                name: name,
+                time: Date.now(),
+                line: toLine(chunk)
+              }
+
+    if (opts.addLabels && data.labels) {
+      var labelsMatch =  new RegExp(opts.labelsMatch || '.*')
+      obj.labels = {}
+
+      Object.keys(data.labels).forEach(function (label) {
+        if (label.match(labelsMatch)) {
+          if (opts.labelsKey) {
+            obj[opts.labelsKey][label] = data.labels[label]
+          } else {
+            obj[label] = data.labels[label]
+          }
+        }
+      })
     }
+
+    return obj
   }
 
   function toLineJSON (line) {

--- a/loghose.js
+++ b/loghose.js
@@ -24,7 +24,8 @@ function cli () {
     console.log('Usage: docker-loghose [--json] [--newline] [--help]\n' +
                 '                      [--nameLabel label]\n' +
                 '                      [--matchByImage REGEXP] [--matchByName REGEXP]\n' +
-                '                      [--skipByImage REGEXP] [--skipByName REGEXP]')
+                '                      [--skipByImage REGEXP] [--skipByName REGEXP]\n' +
+                '                      [--addLabels] [--labelsKey keyname] [--labelsMatch REGEXP]')
     process.exit(1)
   }
 
@@ -35,6 +36,9 @@ function cli () {
     matchByImage: argv.matchByImage,
     skipByName: argv.skipByName,
     skipByImage: argv.skipByImage,
+    addLabels: argv.addLabels,
+    labelsKey: argv.labelsKey,
+    labelsMatch: argv.labelsMatch,
     newline: argv.newline,
     json: argv.json
   }).pipe(through.obj(function (chunk, enc, cb) {


### PR DESCRIPTION
Add Docker Labels to each log entry.

* Switch available to enable adding of labels to log entry
* Option to define a regex to select specific labels
* Put label key/value pairs underneath a single key or in the root of the log object
