### PR TITLE
Updating never-ending-stream to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "bl": "^1.2.0",
     "docker-allcontainers": "^0.7.0",
     "minimist": "^1.1.1",
-    "never-ending-stream": "^1.1.2",
+    "never-ending-stream": "^2.0.0",
     "pump": "^1.0.0",
     "through2": "^2.0.0"
   },


### PR DESCRIPTION
The old version of never-ending-stream uses through2 v0.6.5, which caused more memory leaks.
Still an issue somewhere in node 8.

Tested using an updated version of https://github.com/rapid7/docker-logentries